### PR TITLE
add better handling of empty channels

### DIFF
--- a/compressed_image/include/compressed/util.h
+++ b/compressed_image/include/compressed/util.h
@@ -115,6 +115,12 @@ namespace NAMESPACE_COMPRESSED_IMAGE
 		template <typename T>
 		size_t align_chunk_to_scanlines_elems(size_t width, size_t chunk_size)
 		{
+			// Avoid division by zero, for an empty channel we use a chunk size equivalent to the input data.
+			if (width == 0)
+			{
+				return chunk_size;
+			}
+
 			// The flooring here is intentional, we want to exclude any partial scanlines.
 			size_t num_scanlines = chunk_size / sizeof(T) / width;
 			if (num_scanlines == 0)

--- a/test/src/test_channel.cpp
+++ b/test/src/test_channel.cpp
@@ -43,6 +43,22 @@ TEST_CASE("Initialize channel from incorrect span"
 
 // -----------------------------------------------------------------------------------
 // -----------------------------------------------------------------------------------
+TEST_CASE("Empty channel creation")
+{
+	auto vec = std::vector<uint8_t>(0);
+
+	auto channel = compressed::channel<uint8_t>(std::span<uint8_t>(vec), 0, 0);
+	
+	CHECK(channel.uncompressed_size() == 0);
+	CHECK(channel.width() == 0);
+	CHECK(channel.height() == 0);
+
+	auto decompressed = channel.get_decompressed();
+	CHECK(decompressed.size() == 0);
+}
+
+// -----------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------
 TEST_CASE("Roundtrip channel creation")
 {
 	auto vec = std::vector<uint8_t>(50);


### PR DESCRIPTION
We weren't properly supporting empty channels leading to a zero division error on channel initialization.